### PR TITLE
Adding contentSecurityNonce option to settings

### DIFF
--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -394,6 +394,12 @@ var constructor = function() {
                     options.baseUrl = customUrl;
                 }
             }
+            
+            if (forwarderSettings.contentSecurityNonce) {
+                options.contentSecurityNonce =
+                    forwarderSettings.contentSecurityNonce;
+            }
+            
             if (testMode !== true) {
                 appboy.initialize(forwarderSettings.apiKey, options);
                 finishAppboyInitialization(forwarderSettings);


### PR DESCRIPTION
# Summary

Allows to set the nonce value in the Braze event connection settings. That value will be passed to the contentSecurityNonce initialization option to propagate it to newly created scripts and styles generated by the Braze SDK - https://www.braze.com/docs/developer_guide/platform_integration_guides/web/content_security_policy/#nonce
