### PR TITLE
Adding customFlags API parameter

### DIFF
--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -399,7 +399,7 @@ var constructor = function() {
             
             if (mpCustomFlags && mpCustomFlags[moduleId.toString()]) {
                 var brazeFlags = mpCustomFlags[moduleId];
-                if (typeof brazeFlags.initOptions == 'function') {
+                if (typeof brazeFlags.initOptions === 'function') {
                     brazeFlags.initOptions(options)
                 }
             }

--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -39,7 +39,8 @@ var constructor = function() {
     var self = this,
         forwarderSettings,
         options = {},
-        reportingService;
+        reportingService,
+        mpCustomFlags;
 
     self.name = name;
 
@@ -358,8 +359,9 @@ var constructor = function() {
         }
     }
 
-    function initForwarder(settings, service, testMode) {
+    function initForwarder(settings, service, testMode, customFlags) {
         // eslint-disable-line no-unused-vars
+        mpCustomFlags = customFlags;
         try {
             forwarderSettings = settings;
             reportingService = service;
@@ -394,6 +396,13 @@ var constructor = function() {
                     options.baseUrl = customUrl;
                 }
             }
+            
+            if (mpCustomFlags && mpCustomFlags['BRAZE']) {
+                for (var key in mpCustomFlags.BRAZE) {
+                    options[key] = mpCustomFlags.BRAZE[key]
+                }
+            }
+            
             if (testMode !== true) {
                 appboy.initialize(forwarderSettings.apiKey, options);
                 finishAppboyInitialization(forwarderSettings);

--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -397,7 +397,7 @@ var constructor = function() {
                 }
             }
             
-            if (mpCustomFlags && mpCustomFlags[moduleId]) {
+            if (mpCustomFlags && mpCustomFlags[moduleId.toString()]) {
                 var brazeFlags = mpCustomFlags[moduleId];
                 if (typeof brazeFlags.initOptions == 'function') {
                     brazeFlags.initOptions(options)

--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -359,7 +359,7 @@ var constructor = function() {
         }
     }
 
-    function initForwarder(settings, service, testMode, customFlags) {
+    function initForwarder(settings, service, testMode, trackerId, userAttributes, userIdentities, appVersion, appName, customFlags) {
         // eslint-disable-line no-unused-vars
         mpCustomFlags = customFlags;
         try {

--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -398,7 +398,7 @@ var constructor = function() {
             }
             
             if (mpCustomFlags && mpCustomFlags[moduleId.toString()]) {
-                var brazeFlags = mpCustomFlags[moduleId];
+                var brazeFlags = mpCustomFlags[moduleId.toString()];
                 if (typeof brazeFlags.initOptions === 'function') {
                     brazeFlags.initOptions(options)
                 }

--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -397,9 +397,10 @@ var constructor = function() {
                 }
             }
             
-            if (mpCustomFlags && mpCustomFlags['BRAZE']) {
-                for (var key in mpCustomFlags.BRAZE) {
-                    options[key] = mpCustomFlags.BRAZE[key]
+            if (mpCustomFlags && mpCustomFlags[moduleId]) {
+                var brazeFlags = mpCustomFlags[moduleId];
+                if (typeof brazeFlags.initOptions == 'function') {
+                    brazeFlags.initOptions(options)
                 }
             }
             

--- a/test/boilerplate/test-index.js
+++ b/test/boilerplate/test-index.js
@@ -5,6 +5,6 @@ window.mParticle.addForwarder = function(forwarder) {
     window.mParticle.forwarder = new forwarder.constructor();
 };
 
-require('../../dist/AppboyKit.common.js');
+require('../../dist/BrazeKit.common.js');
 require('../mockhttprequest');
 require('../tests.js');

--- a/test/index.html
+++ b/test/index.html
@@ -21,7 +21,7 @@
 
         window.mParticle = new mp();
     </script>
-    <script src="../dist/AppboyKit.iife.js" data-cover></script>
+    <script src="../dist/BrazeKit.iife.js" data-cover></script>
 
     <script>mocha.setup('bdd')</script>
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -175,6 +175,7 @@ describe('Appboy Forwarder', function() {
             };
 
             this.initialize = function(apiKey, options) {
+                self.options = options;
                 self.initializeCalled = true;
                 self.apiKey = apiKey;
                 self.baseUrl = options.baseUrl || null;
@@ -1264,5 +1265,33 @@ describe('Appboy Forwarder', function() {
         });
 
         window.appboy.should.have.property('doNotLoadFontAwesome', false);
+    });
+
+    it('should add additional braze settings passed from custom flags to the options object', function() {
+        window.appboy = new MockAppboy();
+        mParticle.forwarder.init(
+            {
+                doNotLoadFontAwesome: null,
+                apiKey: 'test',
+            },
+            null,
+            true,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+                28: {
+                    initOptions: function(options) {
+                        options.brazeSetting1 = true;
+                        options.brazeSetting2 = true;
+                    },
+                },
+            }
+        );
+
+        window.appboy.options.should.have.property('brazeSetting1', true);
+        window.appboy.options.should.have.property('brazeSetting2', true);
     });
 });


### PR DESCRIPTION
# Summary

Adding the customFlags parameter that allows to expose an API to pass any optional initialization parameters to the Braze web SDK.


