### PR TITLE
fix: add register_inapp and pushPrimer variables

### DIFF
--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -313,18 +313,19 @@ var constructor = function() {
     }
 
     function primeAppBoyWebPush() {
-        // The following code block is Braze's best practice for implementing
-        // their push primer.  It should not be changed unless Braze updates it
+        // The following code block is based on Braze's best practice for implementing
+        // their push primer.  We only modify it to include pushPrimer and register_inapp settings.
         // https://www.braze.com/docs/developer_guide/platform_integration_guides/web/push_notifications/integration/#soft-push-prompts
         appboy.subscribeToInAppMessage(function(inAppMessage) {
             var shouldDisplay = true;
-
+            var pushPrimer = false;
             if (inAppMessage instanceof appboy.InAppMessage) {
                 // Read the key-value pair for msg-id
                 var msgId = inAppMessage.extras['msg-id'];
 
                 // If this is our push primer message
                 if (msgId == 'push-primer') {
+                    pushPrimer = true;
                     // We don't want to display the soft push prompt to users on browsers that don't support push, or if the user
                     // has already granted/blocked permission
                     if (
@@ -345,8 +346,11 @@ var constructor = function() {
                 }
             }
 
-            // Display the message
-            if (shouldDisplay) {
+            // Display the message if it's a push primer message and shouldDisplay is true
+            if (
+                (pushPrimer && shouldDisplay) ||
+                (!pushPrimer && forwarderSettings.register_inapp === 'True')
+            ) {
                 appboy.display.showInAppMessage(inAppMessage);
             }
         });


### PR DESCRIPTION
# Summary

While a majority of our `primeAppBoyWebPush` function is based off of Braze's [docs here](https://github.com/braze-inc/braze-docs/blob/72ddb341d8d3f14eb7a730cb0a0541449ce9c74a/_docs/_developer_guide/platform_integration_guides/web/push_notifications/soft_push_prompt.md), we modify it slightly to incorporate a `register_inapp` setting from our UI.   Over in the appboy repo, this was added as part of the commit [here](https://github.com/mparticle-integrations/mparticle-javascript-integration-appboy/pull/9/commits/0bce650d762d7a3be23e01e58a281e944cb0c104), but it was left off in the Braze 3.5 upgrade.