### PR TITLE
fix: Add Transaction Id to Purchase Commerce Events

### DIFF
--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -35,7 +35,7 @@ var clusterMapping = {
     EU02: 'sdk.fra-02.braze.eu',
 };
 
-var constructor = function() {
+var constructor = function () {
     var self = this,
         forwarderSettings,
         options = {},
@@ -69,7 +69,7 @@ var constructor = function() {
     function logPurchaseEvent(event) {
         var reportEvent = false;
         if (event.ProductAction.ProductList) {
-            event.ProductAction.ProductList.forEach(function(product) {
+            event.ProductAction.ProductList.forEach(function (product) {
                 if (product.Attributes == null) {
                     product.Attributes = {};
                 }
@@ -86,9 +86,12 @@ var constructor = function() {
                     );
                 }
 
-                var sanitizedProperties = getSanitizedCustomProperties(
-                    product.Attributes
-                );
+                var productAttributes = mergeObjects(product.Attributes, {
+                    'Transaction Id': event.ProductAction.TransactionId,
+                });
+
+                var sanitizedProperties =
+                    getSanitizedCustomProperties(productAttributes);
 
                 if (sanitizedProperties == null) {
                     return (
@@ -248,9 +251,8 @@ var constructor = function() {
         ) {
             reportEvent = logPurchaseEvent(event);
         } else if (event.EventDataType == MessageType.Commerce) {
-            var listOfPageEvents = mParticle.eCommerce.expandCommerceEvent(
-                event
-            );
+            var listOfPageEvents =
+                mParticle.eCommerce.expandCommerceEvent(event);
             if (listOfPageEvents != null) {
                 for (var i = 0; i < listOfPageEvents.length; i++) {
                     // finalLoopResult keeps track of if any logAppBoyEvent in this loop returns true or not
@@ -374,7 +376,7 @@ var constructor = function() {
         // The following code block is based on Braze's best practice for implementing
         // their push primer.  We only modify it to include pushPrimer and register_inapp settings.
         // https://www.braze.com/docs/developer_guide/platform_integration_guides/web/push_notifications/integration/#soft-push-prompts
-        appboy.subscribeToInAppMessage(function(inAppMessage) {
+        appboy.subscribeToInAppMessage(function (inAppMessage) {
             var shouldDisplay = true;
             var pushPrimer = false;
             if (inAppMessage instanceof appboy.InAppMessage) {
@@ -396,7 +398,7 @@ var constructor = function() {
                     if (inAppMessage.buttons[0] != null) {
                         // Prompt the user when the first button is clicked
                         inAppMessage.buttons[0].subscribeToClickedEvent(
-                            function() {
+                            function () {
                                 appboy.registerAppboyPushMessages();
                             }
                         );
@@ -441,7 +443,7 @@ var constructor = function() {
         if (!self.logger) {
             // create a logger
             self.logger = {
-                verbose: function() {},
+                verbose: function () {},
             };
         }
         // eslint-disable-line no-unused-vars
@@ -614,7 +616,7 @@ var constructor = function() {
         var nonMethodArguments = Array.prototype.slice.call(arguments, 1);
         msg += '\n' + method + ':\n';
 
-        nonMethodArguments.forEach(function(arg) {
+        nonMethodArguments.forEach(function (arg) {
             if (isObject(arg) || Array.isArray(arg)) {
                 msg += JSON.stringify(arg);
             } else {
@@ -669,6 +671,18 @@ if (window && window.mParticle && window.mParticle.addForwarder) {
     });
 }
 
+function mergeObjects() {
+    var resObj = {};
+    for (var i = 0; i < arguments.length; i += 1) {
+        var obj = arguments[i],
+            keys = Object.keys(obj);
+        for (var j = 0; j < keys.length; j += 1) {
+            resObj[keys[j]] = obj[keys[j]];
+        }
+    }
+    return resObj;
+}
+
 function isObject(val) {
     return (
         val != null && typeof val === 'object' && Array.isArray(val) === false
@@ -677,7 +691,7 @@ function isObject(val) {
 
 module.exports = {
     register: register,
-    getVersion: function() {
+    getVersion: function () {
         return version;
     },
 };


### PR DESCRIPTION
## Summary
Transaction IDs are normally passed into all commerce events as a `ProductAction` attribute. When Commerce Events are processed by this kit, Non-Purchase Commerce Events are processed through a function that calls `mParticle.eCommerce.expandCommerceEvent` which breaks up individual products within the event into separate events, which handles including `Transaction Id` as an Event Attribute in the expand events.

Purchase Commerce Events do not go through this expanded events process, and therefore their Transaction Id is not being included when logged to Braze.

To resolve this, we should now inject the Transaction Id into the Product Event's attribute sanitization process before logging to Braze.

## Testing Plan
- Automated and Manual Testing

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4370
