### PR TITLE
feat: bump braze to v4.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "watchify": "^3.11.1"
     },
     "dependencies": {
-        "@braze/web-sdk": "^4.2.1",
+        "@braze/web-sdk": "^4.6.1",
         "@mparticle/web-sdk": "^2.17.0"
     },
     "license": "Apache-2.0"


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - bumps braze sdk version to 4.6.1 (branched off of the previous major upgrade branch to 4.x)

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
