### PR TITLE
fix: Add suffix of v$ to forwarder

### DIFF
--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -15,6 +15,7 @@ window.appboy = require('@braze/web-sdk');
 //  limitations under the License.
 
 var name = 'Appboy',
+    suffix = 'v3',
     moduleId = 28,
     version = '3.0.6',
     MessageType = {
@@ -43,6 +44,7 @@ var constructor = function () {
         mpCustomFlags;
 
     self.name = name;
+    self.suffix = suffix;
 
     var DefaultAttributeMethods = {
         $LastName: 'setLastName',
@@ -637,9 +639,11 @@ function getId() {
 }
 
 function register(config) {
+    var forwarderNameWithSuffix = [name, suffix].join('-');
     if (!config) {
         window.console.log(
-            'You must pass a config object to register the kit ' + name
+            'You must pass a config object to register the kit ' +
+                forwarderNameWithSuffix
         );
         return;
     }
@@ -652,17 +656,19 @@ function register(config) {
     }
 
     if (isObject(config.kits)) {
-        config.kits[name] = {
+        config.kits[forwarderNameWithSuffix] = {
             constructor: constructor,
         };
     } else {
         config.kits = {};
-        config.kits[name] = {
+        config.kits[forwarderNameWithSuffix] = {
             constructor: constructor,
         };
     }
     window.console.log(
-        'Successfully registered ' + name + ' to your mParticle configuration'
+        'Successfully registered ' +
+            forwarderNameWithSuffix +
+            ' to your mParticle configuration'
     );
 }
 
@@ -671,6 +677,9 @@ if (window && window.mParticle && window.mParticle.addForwarder) {
         name: name,
         constructor: constructor,
         getId: getId,
+        // A suffix is added if there are multiple different versions of
+        // a client kit.  This matches the suffix in the DB.
+        suffix: suffix,
     });
 }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,4 +1,12 @@
 /* eslint-disable no-undef */
+// If we are testing this in a node environemnt, we load the common.js Braze kit
+
+var brazeInstance;
+if (typeof require !== 'undefined') {
+    brazeInstance = require('../dist/BrazeKit.common').default;
+} else {
+    brazeInstance = mpBrazeKit.default;
+}
 
 describe('Appboy Forwarder', function () {
     var expandCommerceEvent = function (event) {
@@ -290,6 +298,17 @@ describe('Appboy Forwarder', function () {
         window.appboy.should.have.property('apiKey', '123456');
         window.appboy.should.have.property('metadata', ['mp']);
     });
+
+     it('should have a property of suffix', function() {
+         window.mParticle.forwarder.should.have.property('suffix', 'v3');
+     });
+
+     it('should register a forwarder with version number onto a config', function() {
+         var config = {};
+         brazeInstance.register(config);
+         config.should.have.property('kits');
+         config.kits.should.have.property('Appboy-v3');
+     });
 
     it('should open a new session and refresh in app messages upon initialization', function() {
         window.appboy.should.have.property('initializeCalled', true);
@@ -919,8 +938,8 @@ describe('Appboy Forwarder', function () {
         // We support $Age as a reserved attribute for Braze. However, since
         // Braze's API expects a year from us, this test will break every year,
         // since setting the age = 10 in 2021 will mean the user is born in 2011,
-        // but setting it in 2022 means the year is 2012.
-        window.appboy.getUser().yearOfBirth.should.equal(2012);
+        // but setting it in 2023 means the year is 2013.
+        window.appboy.getUser().yearOfBirth.should.equal(2013);
         window.appboy.getUser().dayOfBirth.should.equal(1);
         window.appboy.getUser().monthOfBirth.should.equal(1);
         window.appboy.getUser().phoneSet.should.equal('1234567890');


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
In order to support allowing multiple versions of our client side kit to be served, we add support for a suffix config item. This is for V3.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
Locally tested to see if this worked with the core SDK

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5443