### PR TITLE
feat: Support single commerce transaction with bundles

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,9 +1,11 @@
 {
     "env": {
-        "browser": true
+        "browser": true,
+        "es6": true
     },
     "globals": {
-        "appboy": true
+        "braze": true,
+        "mParticle": true,
     },
     "extends": ["plugin:prettier/recommended", "eslint:recommended"],
     "rules": {

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 test/test-bundle.js
+.DS_Store

--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -73,14 +73,14 @@ var constructor = function () {
         dob: 'setDateOfBirth',
     };
 
-    var bundleProductsWithCommerceEvents = false;
+    var bundleCommerceEventData = false;
 
     // A purchase event can either log a single event with all products
     // or multiple purchase events (one per product)
     function logPurchaseEvent(event) {
         var reportEvent = false;
 
-        if (bundleProductsWithCommerceEvents) {
+        if (bundleCommerceEventData) {
             reportEvent = logSinglePurchaseEventWithProducts(event);
         } else {
             reportEvent = logPurchaseEventPerProduct(event);
@@ -352,7 +352,7 @@ var constructor = function () {
     // A non-purchase commerce event can either log a single event with all products
     // or one event per product when the commerce event is expanded
     function logNonPurchaseCommerceEvent(event) {
-        if (bundleProductsWithCommerceEvents) {
+        if (bundleCommerceEventData) {
             return logNonPurchaseCommerceEventWithProducts(event);
         } else {
             return logExpandedNonPurchaseCommerceEvents(event);
@@ -649,8 +649,8 @@ var constructor = function () {
         mpCustomFlags = customFlags;
         try {
             forwarderSettings = settings;
-            bundleProductsWithCommerceEvents =
-                forwarderSettings.bundleProductsWithCommerceEvents === 'True';
+            bundleCommerceEventData =
+                forwarderSettings.bundleCommerceEventData === 'True';
             reportingService = service;
             // 30 min is Braze default
             options.sessionTimeoutInSeconds =

--- a/test/index.html
+++ b/test/index.html
@@ -6,20 +6,14 @@
 </head>
 <body>
     <div id="mocha"></div>
-
+    <script src="../node_modules/@mparticle/web-sdk/dist/mparticle.js"></script>
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="../node_modules/should/should.js"></script>
     <script src="mockhttprequest.js"></script>
     <script>
-        var mp = function () {
-            var self = this;
-
-            this.addForwarder = function (forwarder) {
-                self.forwarder = new forwarder.constructor();
-            }
-        };
-
-        window.mParticle = new mp();
+        mParticle.addForwarder = function (forwarder) {
+            mParticle.forwarder = new forwarder.constructor();
+        }
     </script>
     <script src="../dist/BrazeKit.iife.js" data-cover></script>
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -1521,13 +1521,13 @@ USD,
         window.braze.options.should.have.property('brazeSetting2', true);
     });
 
-    it.only('should log a single non-purchase commerce event with multiple products if bundleProductsWithCommerceEvents is `True`', function() {
+    it('should log a single non-purchase commerce event with multiple products if bundleCommerceEventData is `True`', function() {
         window.braze = new MockBraze();
 
         mParticle.forwarder.init(
             {
                 apiKey: '9123456',
-                bundleProductsWithCommerceEvents: 'True',
+                bundleCommerceEventData: 'True',
             },
             reportService.cb,
             true,
@@ -1611,12 +1611,12 @@ USD,
         loggedNonPurchaseCommerce.should.eql(expectedNonPurchaseCommerceEvent);
     });
 
-    it('should log a single purchase commerce event with multiple products if bundleProductsWithCommerceEvents is `True`', function() {
+    it('should log a single purchase commerce event with multiple products if bundleCommerceEventData is `True`', function() {
         window.braze = new MockBraze();
         mParticle.forwarder.init(
             {
                 apiKey: '9123456',
-                bundleProductsWithCommerceEvents: 'True',
+                bundleCommerceEventData: 'True',
             },
             reportService.cb,
             true,
@@ -1761,7 +1761,7 @@ USD,
             mParticle.forwarder.init(
                 {
                     apiKey: '9123456',
-                    bundleProductsWithCommerceEvents: 'True',
+                    bundleCommerceEventData: 'True',
                 },
                 reportService.cb,
                 true,
@@ -1973,7 +1973,7 @@ USD,
             mParticle.forwarder.init(
                 {
                     apiKey: '9123456',
-                    bundleProductsWithCommerceEvents: 'True',
+                    bundleCommerceEventData: 'True',
                 },
                 reportService.cb,
                 true,


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
* Currently when we send commerce events, we expand purchase events and nonpurchase-commerce events and send individual events per product. This change introduces a flag to allow bundling products into a single event.
* This PR is an exact copy (plus changing references from `appboy` to `braze` of all the lines previously approved and sitting in this [git diff](https://github.com/mparticle-integrations/mparticle-javascript-integration-braze/compare/651efb414cd129a5c261f7a95e857d7114787e3a...8630879bfce63ad2cb11e611f2ff9c9dafd62f2f)


 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5405
