### PR TITLE
fix: Update ecommerce name casing

### DIFF
--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -407,7 +407,7 @@ var constructor = function () {
 
     function logNonPurchaseCommerceEventWithProducts(mpEvent) {
         const commerceEventAttrs = {};
-        let eventName = getCommerceEventName(mpEvent.EventCategory);
+        const eventName = getCommerceEventName(mpEvent.EventCategory);
         try {
             switch (mpEvent.EventCategory) {
                 case mParticle.CommerceEventType.PromotionClick:

--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -22,7 +22,8 @@ var name = 'Appboy',
         PageView: 3,
         PageEvent: 4,
         Commerce: 16,
-    };
+    },
+    CommerceEventType = mParticle.CommerceEventType;
 
 var clusterMapping = {
     '01': 'sdk.iad-01.braze.com',
@@ -191,43 +192,43 @@ var constructor = function () {
         let eventName;
 
         switch (eventType) {
-            case mParticle.CommerceEventType.ProductAddToCart:
+            case CommerceEventType.ProductAddToCart:
                 eventName = 'add_to_cart';
                 break;
-            case mParticle.CommerceEventType.ProductRemoveFromCart:
+            case CommerceEventType.ProductRemoveFromCart:
                 eventName = 'remove_from_cart';
                 break;
-            case mParticle.CommerceEventType.ProductCheckout:
+            case CommerceEventType.ProductCheckout:
                 eventName = 'checkout';
                 break;
-            case mParticle.CommerceEventType.ProductCheckoutOption:
+            case CommerceEventType.ProductCheckoutOption:
                 eventName = 'checkout_option';
                 break;
-            case mParticle.CommerceEventType.ProductClick:
+            case CommerceEventType.ProductClick:
                 eventName = 'click';
                 break;
-            case mParticle.CommerceEventType.ProductViewDetail:
+            case CommerceEventType.ProductViewDetail:
                 eventName = 'view_detail';
                 break;
-            case mParticle.CommerceEventType.ProductPurchase:
+            case CommerceEventType.ProductPurchase:
                 eventName = 'purchase';
                 break;
-            case mParticle.CommerceEventType.ProductRefund:
+            case CommerceEventType.ProductRefund:
                 eventName = 'refund';
                 break;
-            case mParticle.CommerceEventType.ProductAddToWishlist:
+            case CommerceEventType.ProductAddToWishlist:
                 eventName = 'add_to_wishlist';
                 break;
-            case mParticle.CommerceEventType.ProductRemoveFromWishlist:
+            case CommerceEventType.ProductRemoveFromWishlist:
                 eventName = 'remove_from_wishlist';
                 break;
-            case mParticle.CommerceEventType.PromotionView:
+            case CommerceEventType.PromotionView:
                 eventName = 'view';
                 break;
-            case mParticle.CommerceEventType.PromotionClick:
+            case CommerceEventType.PromotionClick:
                 eventName = 'click';
                 break;
-            case mParticle.CommerceEventType.ProductImpression:
+            case CommerceEventType.ProductImpression:
                 eventName = 'Impression';
                 break;
             default:
@@ -384,9 +385,7 @@ var constructor = function () {
     // mParticle commerce events use different appboy methods depending on if they are
     // a purchase event or a non-purchase commerce event
     function logCommerceEvent(event) {
-        if (
-            event.EventCategory === mParticle.CommerceEventType.ProductPurchase
-        ) {
+        if (event.EventCategory === CommerceEventType.ProductPurchase) {
             reportEvent = logPurchaseEvent(event);
             return reportEvent === true;
         } else {
@@ -410,13 +409,13 @@ var constructor = function () {
         const eventName = getCommerceEventName(mpEvent.EventCategory);
         try {
             switch (mpEvent.EventCategory) {
-                case mParticle.CommerceEventType.PromotionClick:
-                case mParticle.CommerceEventType.PromotionView:
+                case CommerceEventType.PromotionClick:
+                case CommerceEventType.PromotionView:
                     commerceEventAttrs.promotions = addPromotions(
                         mpEvent.PromotionAction
                     );
                     break;
-                case mParticle.CommerceEventType.ProductImpression:
+                case CommerceEventType.ProductImpression:
                     commerceEventAttrs.impressions = addImpressions(
                         mpEvent.ProductImpressions
                     );

--- a/test/tests.js
+++ b/test/tests.js
@@ -5,7 +5,7 @@ var brazeInstance;
 if (typeof require !== 'undefined') {
     brazeInstance = require('../dist/BrazeKit.common').default;
 } else {
-    brazeInstance = mpBrazeKit.default;
+    brazeInstance = mpBrazeKitV3.default;
 }
 
 describe('Appboy Forwarder', function () {
@@ -298,16 +298,16 @@ describe('Appboy Forwarder', function () {
         window.appboy.should.have.property('metadata', ['mp']);
     });
 
-     it('should have a property of suffix', function() {
-         window.mParticle.forwarder.should.have.property('suffix', 'v3');
-     });
+    it('should have a property of suffix', function() {
+        window.mParticle.forwarder.should.have.property('suffix', 'v3');
+    });
 
-     it('should register a forwarder with version number onto a config', function() {
-         var config = {};
-         brazeInstance.register(config);
-         config.should.have.property('kits');
-         config.kits.should.have.property('Appboy-v3');
-     });
+    it('should register a forwarder with version number onto a config', function() {
+        var config = {};
+        brazeInstance.register(config);
+        config.should.have.property('kits');
+        config.kits.should.have.property('Appboy-v3');
+    });
 
     it('should open a new session and refresh in app messages upon initialization', function() {
         window.appboy.should.have.property('initializeCalled', true);
@@ -1554,7 +1554,7 @@ USD,
         mParticle.forwarder.process({
             EventName: 'eCommerce - AddToCart',
             EventDataType: MessageType.Commerce,
-            EventCategory: CommerceEventType.AddToCart,
+            EventCategory: CommerceEventType.ProductAddToCart,
             EventAttributes: customAttributes,
             CurrencyCode: 'USD',
             ProductAction: {
@@ -1588,7 +1588,7 @@ USD,
         window.appboy.logCustomEventCalled.should.equal(true);
 
         var expectedNonPurchaseCommerceEvent = {
-            name: 'eCommerce - AddToCart',
+            name: 'eCommerce - add_to_cart',
             eventProperties: {
                 'Transaction Id': 91234,
                 foo: 'bar',
@@ -1675,7 +1675,7 @@ USD,
         });
 
         var expectedPurchaseEvent = [
-            'eCommerce - Purchase',
+            'eCommerce - purchase',
             50,
             1,
             {
@@ -1710,7 +1710,7 @@ USD,
         window.appboy.should.have.property('logPurchaseEventCalled', true);
         window.appboy.should.have.property(
             'logPurchaseName',
-            'eCommerce - Purchase'
+            'eCommerce - purchase'
         );
         var purchaseEventProperties = window.appboy.purchaseEventProperties[0];
 
@@ -1786,7 +1786,7 @@ USD,
             const promotionEvent = window.appboy.loggedEvents[0];
 
             const expectedPromotionEvent = {
-                name: 'eCommerce - PromotionClick',
+                name: 'eCommerce - click',
                 eventProperties: {
                     promotions: [
                         {

--- a/test/tests.js
+++ b/test/tests.js
@@ -33,21 +33,7 @@ describe('Appboy Forwarder', function () {
                 return 'blahblah';
             },
         },
-        CommerceEventType = {
-            ProductAddToCart: 10,
-            ProductRemoveFromCart: 11,
-            ProductCheckout: 12,
-            ProductCheckoutOption: 13,
-            ProductClick: 14,
-            ProductViewDetail: 15,
-            ProductPurchase: 16,
-            ProductRefund: 17,
-            PromotionView: 18,
-            PromotionClick: 19,
-            ProductAddToWishlist: 20,
-            ProductRemoveFromWishlist: 21,
-            ProductImpression: 22,
-        },
+        CommerceEventType = mParticle.CommerceEventType,
         IdentityType = {
             Other: 0,
             CustomerId: 1,


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
The casing is `Sentence Case` for regular ecommerce event names (where no expansion occurs), but for ecommerce expanded events, it is `snake_case`.  In order to be consistent with previous behavior, we need to add the `snake_case` constants to the Braze kit.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5505