### PR TITLE
fix: Add custom logging for onUserIdentified

### DIFF
--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -612,26 +612,35 @@ var constructor = function () {
 
     // onUserIdentified is not used in version 1 so there is no need to check for version number
     function onUserIdentified(user) {
-        var brazeUserIDType,
-            userIdentities = user.getUserIdentities().userIdentities;
+        kitLogger('calling MpBrazeKit.onUserIdentified');
 
-        if (forwarderSettings.userIdentificationType === 'MPID') {
-            brazeUserIDType = user.getMPID();
-        } else {
-            brazeUserIDType =
-                userIdentities[
-                    forwarderSettings.userIdentificationType.toLowerCase()
-                ];
-        }
+        try {
+            var brazeUserIDType,
+                userIdentities = user.getUserIdentities().userIdentities;
 
-        kitLogger('braze.changeUser', brazeUserIDType);
+            if (forwarderSettings.userIdentificationType === 'MPID') {
+                brazeUserIDType = user.getMPID();
+            } else {
+                brazeUserIDType =
+                    userIdentities[
+                        forwarderSettings.userIdentificationType.toLowerCase()
+                    ];
+            }
 
-        braze.changeUser(brazeUserIDType);
+            kitLogger('braze.changeUser', brazeUserIDType);
 
-        if (userIdentities.email) {
-            kitLogger('braze.getUser().setEmail', userIdentities.email);
+            braze.changeUser(brazeUserIDType);
 
-            braze.getUser().setEmail(userIdentities.email);
+            if (userIdentities.email) {
+                kitLogger('braze.getUser().setEmail', userIdentities.email);
+
+                braze.getUser().setEmail(userIdentities.email);
+            }
+        } catch (e) {
+            kitLogger(
+                'Error in calling MpBrazeKit.onUserIdentified',
+                e.message
+            );
         }
     }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -1144,6 +1144,56 @@ USD,
         mParticle.forwarder.msg.should.equal(expectedMessage);
     });
 
+    it('should log initial onUserIdentified message', function() {
+        var logs = [];
+
+        mParticle.forwarder.init({
+            apiKey: '123456',
+            userIdentificationType: 'email',
+        });
+
+        mParticle.forwarder.logger = {
+            verbose: function(msg) {
+                logs.push(msg);
+            },
+        };
+        mParticle.forwarder.onUserIdentified({
+            getUserIdentities: function() {
+                return {
+                    userIdentities: { email: 'test@test.test' },
+                };
+            },
+        });
+
+        var expectedMessage = `mParticle - Braze Web Kit log:
+calling MpBrazeKit.onUserIdentified:\n`;
+
+        logs[0].should.equal(expectedMessage);
+    });
+
+    it('should log errors in onUserIdentified', function() {
+        var logs = [];
+
+        mParticle.forwarder.init({
+            apiKey: '123456',
+            userIdentificationType: 'email',
+        });
+
+        mParticle.forwarder.logger = {
+            verbose: function(msg) {
+                logs.push(msg);
+            },
+        };
+
+        mParticle.forwarder.onUserIdentified({});
+
+        var expectedMessage = `mParticle - Braze Web Kit log:
+Error in calling MpBrazeKit.onUserIdentified:
+user.getUserIdentities is not a function,\n`;
+
+        logs[1].should.equal(expectedMessage);
+    });
+
     it('should not set baseUrl when passed an invalid cluster', function() {
         reportService.reset();
         window.braze = new MockBraze();


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
In a previous [PR](https://github.com/mparticle-integrations/mparticle-javascript-integration-braze/pull/10/files) we added custom logging to allow a customer to debug what was happening in their Braze kit.  We received an additional request to add logging around the `onUserIdentified` method to get slightly more granular error messaging to see if there are any errors occurring here.  In this PR, a try/catch block is added to see if `onUserIdentified` is called from our side.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
Unit tests added. Tested in an app as well.  

Successful console.log shown below:
![image](https://github.com/mparticle-integrations/mparticle-javascript-integration-braze/assets/5377436/e6076958-ea52-4a66-8167-16601253e371)


 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5068
