### PR TITLE
fix: Forward SKU as product name when ecommerce events are bundled

### DIFF
--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -70,6 +70,7 @@ var constructor = function () {
     };
 
     var bundleCommerceEventData = false;
+    var forwardSkuAsProductName = false;
 
     // A purchase event can either log a single event with all products
     // or multiple purchase events (one per product)
@@ -135,7 +136,7 @@ var constructor = function () {
             event.ProductAction.ProductList.forEach(function(product) {
                 var productName;
 
-                if (forwarderSettings.forwardSkuAsProductName === 'True') {
+                if (forwardSkuAsProductName) {
                     productName = product.Sku;
                 } else {
                     productName = product.Name;
@@ -510,11 +511,15 @@ var constructor = function () {
 
     function parseProduct(_product) {
         var product = {};
-
         for (var key in _product) {
             switch (key) {
                 case 'Sku':
                     product.Id = _product[key];
+                    break;
+                case 'Name':
+                    product.Name = forwardSkuAsProductName
+                        ? _product.Sku
+                        : _product.Name;
                     break;
                 case 'CouponCode':
                     product['Coupon Code'] = _product[key];
@@ -724,6 +729,8 @@ var constructor = function () {
             forwarderSettings = settings;
             bundleCommerceEventData =
                 forwarderSettings.bundleCommerceEventData === 'True';
+            forwardSkuAsProductName =
+                forwarderSettings.forwardSkuAsProductName === 'True';
             reportingService = service;
             // 30 min is Braze default
             options.sessionTimeoutInSeconds =

--- a/test/tests.js
+++ b/test/tests.js
@@ -745,6 +745,57 @@ describe('Braze Forwarder', function() {
         window.braze.should.have.property('logPurchaseName', '12345');
     });
 
+    it('should log a purchase event with SKU in place of product name if forwardSkuAsProductName and bundleCommerceEventData are true', function() {
+        mParticle.forwarder.init(
+            {
+                apiKey: '123456',
+                forwardSkuAsProductName: 'True',
+                bundleCommerceEventData: 'True',
+            },
+            reportService.cb,
+            true,
+            null
+        );
+
+        mParticle.forwarder.process({
+            EventName: 'Test Purchase Event',
+            EventAttributes: {},
+            EventDataType: MessageType.Commerce,
+            EventCategory: CommerceEventType.ProductPurchase,
+            CurrencyCode: 'USD',
+            ProductAction: {
+                TransactionId: 1234,
+                TotalAmount: 50,
+                ProductList: [
+                    {
+                        Price: '50',
+                        Name: '$Product $Name',
+                        TotalAmount: 50,
+                        Quantity: 1,
+                        Attributes: { $$$attri$bute: '$$$$what$ever' },
+                        Sku: '12345',
+                    },
+                    {
+                        Price: '50',
+                        Name: 'Another $Product $Name',
+                        TotalAmount: 50,
+                        Quantity: 1,
+                        Attributes: { $$$attri$bute: '$$$$what$ever2' },
+                        Sku: '2345',
+                    },
+                ],
+            },
+        });
+
+        window.braze.should.have.property('logPurchaseEventCalled', true);
+        braze.purchaseEventProperties[0][3].products[0].Name.should.equal(
+            '12345'
+        );
+        braze.purchaseEventProperties[0][3].products[1].Name.should.equal(
+            '2345'
+        );
+    });
+
     it('should log a page view with the page name if sendEventNameForPageView is true', function() {
         mParticle.forwarder.init(
             {
@@ -1002,7 +1053,7 @@ describe('Braze Forwarder', function() {
         // Braze's API expects a year from us, this test will break every year,
         // since setting the age = 10 in 2021 will mean the user is born in 2011,
         // but setting it in 2023 means the year is 2013.
-        window.braze.getUser().yearOfBirth.should.equal(2013);
+        window.braze.getUser().yearOfBirth.should.equal(2014);
         window.braze.getUser().dayOfBirth.should.equal(1);
         window.braze.getUser().monthOfBirth.should.equal(1);
         window.braze.getUser().phoneSet.should.equal('1234567890');


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
We have a Braze setting `Replace SKU as Braze Product Name` which works when the customer sends an ecommerce events one by one (default).  However, a new feature was added allowing a customer to send all products in a single event.  When this is enabled via checking `Bundle Commerce Event Data`, we do not respect the `Replace Sku as Braze Product Name` selection. Instead we always use the product name.  We should implement this flag so that the expected behavior occurs whether or not  `Bundle eCommerce Data is selected`.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
- Unit tests also added

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6090