### PR TITLE
fix: Allow any userIdentificationType to be used when initializing kit

### DIFF
--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -632,9 +632,11 @@ var constructor = function () {
                     ];
             }
 
-            kitLogger('braze.changeUser', brazeUserIDType);
+            if (brazeUserIDType) {
+                kitLogger('braze.changeUser', brazeUserIDType);
 
-            braze.changeUser(brazeUserIDType);
+                braze.changeUser(brazeUserIDType);
+            }
 
             if (userIdentities.email) {
                 kitLogger('braze.getUser().setEmail', userIdentities.email);

--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -792,10 +792,13 @@ var constructor = function () {
         braze.addSdkMetadata(['mp']);
         primeBrazeWebPush();
 
-        if (forwarderSettings.userIdentificationType === 'MPID' && mParticle.Identity != null && mParticle.Identity.getCurrentUser().getMPID() != null) {
-            onUserIdentified(mParticle.Identity.getCurrentUser())
+        if (
+            mParticle.Identity != null &&
+            mParticle.Identity.getCurrentUser().getMPID() != null
+        ) {
+            onUserIdentified(mParticle.Identity.getCurrentUser());
         }
-        
+
         openSession(forwarderSettings);
     }
 

--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -794,11 +794,11 @@ var constructor = function () {
         braze.addSdkMetadata(['mp']);
         primeBrazeWebPush();
 
-        if (
-            mParticle.Identity != null &&
-            mParticle.Identity.getCurrentUser().getMPID() != null
-        ) {
-            onUserIdentified(mParticle.Identity.getCurrentUser());
+        const currentUser = mParticle.Identity != null ? mParticle.Identity.getCurrentUser() : null;
+        const mpid = currentUser.getMPID();
+        
+        if (currentUser && mpid) {
+            onUserIdentified(currentUser);
         }
 
         openSession(forwarderSettings);

--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -794,9 +794,12 @@ var constructor = function () {
         braze.addSdkMetadata(['mp']);
         primeBrazeWebPush();
 
-        const currentUser = mParticle.Identity != null ? mParticle.Identity.getCurrentUser() : null;
-        const mpid = currentUser.getMPID();
-        
+        const currentUser =
+            mParticle.Identity !== null
+                ? mParticle.Identity.getCurrentUser()
+                : null;
+        const mpid = currentUser ? currentUser.getMPID() : null;
+
         if (currentUser && mpid) {
             onUserIdentified(currentUser);
         }

--- a/test/tests.js
+++ b/test/tests.js
@@ -981,6 +981,15 @@ describe('Braze Forwarder', function() {
         window.braze.getUser().emailSet.should.equal('email@gmail.com');
     });
 
+    it('should not attempt to set an identity on braze if the userIdentificationType does not exist on the customer', function() {
+        mParticle.forwarder.init({
+            apiKey: '123456',
+            userIdentificationType: 'other2',
+        });
+
+        Should(window.braze.userId).equal(null);
+    });
+
     it('should set main braze user identity from userIdentificationType ', function() {
         mParticle.forwarder.init({
             apiKey: '123456',

--- a/test/tests.js
+++ b/test/tests.js
@@ -971,7 +971,7 @@ describe('Braze Forwarder', function() {
         delete mParticle.getVersion;
     });
 
-    it('should set an identity on the user upon kit initialization', function() {
+    it('should set an identity on the user upon kit initialization when userIdentificationType is email', function() {
         mParticle.forwarder.init({
             apiKey: '123456',
             userIdentificationType: 'Email',

--- a/test/tests.js
+++ b/test/tests.js
@@ -254,6 +254,7 @@ describe('Braze Forwarder', function() {
                         return {
                             userIdentities: {
                                 customerid: 'abc',
+                                email: 'email@gmail.com'
                             },
                         };
                     },
@@ -968,6 +969,16 @@ describe('Braze Forwarder', function() {
         (window.braze.getUser().emailSet === null).should.equal(true);
 
         delete mParticle.getVersion;
+    });
+
+    it('should set an identity on the user upon kit initialization', function() {
+        mParticle.forwarder.init({
+            apiKey: '123456',
+            userIdentificationType: 'Email',
+        });
+
+        window.braze.userId.should.equal('email@gmail.com');
+        window.braze.getUser().emailSet.should.equal('email@gmail.com');
     });
 
     it('should set main braze user identity from userIdentificationType ', function() {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development` - Since this is Braze and there is a v3 and a v4, this does not apply as we need to manually release
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
Previously we allowed a user to be identified on initialization only if they chose `MPID` as their `userIdentificationType`.  This prevents customers from being able to use kit forwarding rules in Braze if they have any other `userIdentificationType` picked.  Removing this constraint fixes that.  

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
Added a test setting email to be the `userIdentificationType`

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6345