### PR TITLE
fix: Update package.json to support esm, define missing variable decl…

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,8 @@
     "globals": {
         "braze": true,
         "mParticle": true,
+        "require": true,
+        "module": true
     },
     "extends": ["plugin:prettier/recommended", "eslint:recommended"],
     "rules": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
     "description": "mParticle integration sdk for Braze",
     "main": "dist/BrazeKit.common.js",
     "browser": "dist/BrazeKit.common.js",
+    "module": "dist/BrazeKit.esm.js",
     "files": [
-        "dist/BrazeKit.common.js"
+        "dist/BrazeKit.common.js",
+        "dist/BrazeKit.esm.js"
     ],
     "repository": "https://github.com/mparticle-integrations/mparticle-javascript-integration-braze",
     "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -41,7 +41,6 @@ export default [
         output: {
             file: 'dist/BrazeKit.esm.js',
             format: 'esm',
-            exports: 'named',
             name: 'mpBrazeKitV5',
             strict: false,
             inlineDynamicImports: true,

--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -142,7 +142,7 @@ var constructor = function () {
     }
 
     function logPurchaseEventPerProduct(event) {
-        var reportEvent;
+        var reportEvent = false;
         if (event.ProductAction.ProductList) {
             event.ProductAction.ProductList.forEach(function(product) {
                 var productName;

--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 window.braze = require('@braze/web-sdk');
 //  Copyright 2015 mParticle, Inc.
 //
@@ -131,7 +130,7 @@ var constructor = function () {
             eventAttributes
         );
 
-        reportEvent = braze.logPurchase(
+        var reportEvent = braze.logPurchase(
             eventName,
             event.ProductAction.TotalAmount,
             event.CurrencyCode,
@@ -143,6 +142,7 @@ var constructor = function () {
     }
 
     function logPurchaseEventPerProduct(event) {
+        var reportEvent;
         if (event.ProductAction.ProductList) {
             event.ProductAction.ProductList.forEach(function(product) {
                 var productName;
@@ -399,6 +399,7 @@ var constructor = function () {
     // mParticle commerce events use different Braze methods depending on if they are
     // a purchase event or a non-purchase commerce event
     function logCommerceEvent(event) {
+        var reportEvent = false;
         if (event.EventCategory === CommerceEventType.ProductPurchase) {
             reportEvent = logPurchaseEvent(event);
             return reportEvent === true;
@@ -476,7 +477,7 @@ var constructor = function () {
                 ),
             };
 
-            reportEvent = logBrazeEvent(brazeEvent);
+            var reportEvent = logBrazeEvent(brazeEvent);
             return reportEvent;
         } catch (err) {
             return 'Error logging commerce event' + err.message;
@@ -548,6 +549,7 @@ var constructor = function () {
     }
 
     function logExpandedNonPurchaseCommerceEvents(event) {
+        var reportEvent = false;
         var listOfPageEvents = mParticle.eCommerce.expandCommerceEvent(event);
         if (listOfPageEvents !== null) {
             for (var i = 0; i < listOfPageEvents.length; i++) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -4,7 +4,7 @@ var brazeInstance;
 if (typeof require !== 'undefined') {
     brazeInstance = require('../dist/BrazeKit.common').default;
 } else {
-    brazeInstance = mpBrazeKitV4.default;
+    brazeInstance = mpBrazeKitV5.default;
 }
 
 describe('Braze Forwarder', function() {
@@ -316,14 +316,14 @@ describe('Braze Forwarder', function() {
     });
 
     it('should have a property of suffix', function() {
-        window.mParticle.forwarder.should.have.property('suffix', 'v4');
+        window.mParticle.forwarder.should.have.property('suffix', 'v5');
     });
 
     it('should register a forwarder with version number onto a config', function() {
         var config = {};
         brazeInstance.register(config);
         config.should.have.property('kits');
-        config.kits.should.have.property('Appboy-v4');
+        config.kits.should.have.property('Appboy-v5');
     });
 
     it('should open a new session and refresh in app messages upon initialization', function() {


### PR DESCRIPTION
…arations

## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
When testing E2E in Higgs Sample App, I discovered that the esm module still wasn't being selected, it was still using the common.js file.  This requires updates to package.json to add the `module` key to point to the esm file.  After adding that, I was getting errors about `reportEvent` not being defined.  It looks like my linter was ignoring these errors because of the top comment `/* eslint-disable no-undef */`.  I removed this and instead added the `require` and `module` to the global list in the `eslint` file.  This caught all the undefined instances of `reportEvent`, and I added variable declarations as well. 

This seems to only affect the esm file and it could be the way Higgs shop is configured to perhaps use `strict mode`.  In any case, we should resolve this so that if people are on common.js and using strict mode, it will not throw any errors.

I also fixed some tests which are looking for V4, and these are now updated to V5.  The issue is that the ci/cd on braze needs work because there are multiple master branches for v3, v4, and v5, so its likely that the automated tests were never added to this repository for that reason, which needs to be updated/added.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
Ran E2E using Higgs sample app to include an esm build.  Commerce events that previously threw the error now do not throw any errors.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6901
