### PR TITLE
fix: Declare reportEvent where previously undeclared

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,8 @@
     "globals": {
         "braze": true,
         "mParticle": true,
+        "require": true,
+        "module": true
     },
     "extends": ["plugin:prettier/recommended", "eslint:recommended"],
     "rules": {

--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 window.braze = require('@braze/web-sdk');
 //  Copyright 2015 mParticle, Inc.
 //
@@ -131,7 +130,7 @@ var constructor = function () {
             eventAttributes
         );
 
-        reportEvent = braze.logPurchase(
+        var reportEvent = braze.logPurchase(
             eventName,
             event.ProductAction.TotalAmount,
             event.CurrencyCode,
@@ -143,6 +142,7 @@ var constructor = function () {
     }
 
     function logPurchaseEventPerProduct(event) {
+        var reportEvent = false;
         if (event.ProductAction.ProductList) {
             event.ProductAction.ProductList.forEach(function(product) {
                 var productName;
@@ -399,6 +399,7 @@ var constructor = function () {
     // mParticle commerce events use different Braze methods depending on if they are
     // a purchase event or a non-purchase commerce event
     function logCommerceEvent(event) {
+        var reportEvent = false;
         if (event.EventCategory === CommerceEventType.ProductPurchase) {
             reportEvent = logPurchaseEvent(event);
             return reportEvent === true;
@@ -476,7 +477,7 @@ var constructor = function () {
                 ),
             };
 
-            reportEvent = logBrazeEvent(brazeEvent);
+            var reportEvent = logBrazeEvent(brazeEvent);
             return reportEvent;
         } catch (err) {
             return 'Error logging commerce event' + err.message;
@@ -548,6 +549,7 @@ var constructor = function () {
     }
 
     function logExpandedNonPurchaseCommerceEvents(event) {
+        var reportEvent = false;
         var listOfPageEvents = mParticle.eCommerce.expandCommerceEvent(event);
         if (listOfPageEvents !== null) {
             for (var i = 0; i < listOfPageEvents.length; i++) {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
There are parts of the code where reportEvent is assigned a value but not previously declared. This PR resolve it.  Similar to changes made for [v5 in this PR.](https://github.com/mparticle-integrations/mparticle-javascript-integration-braze/pull/54)

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
We are just practicing more defensive coding measures and so there is not any change to the unit tests.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6919