### PR TITLE
Fix: Replace enableHtmlInAppMessages deprecated method with allowUserSuppliedJavascript (v3)

### DIFF
--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -460,7 +460,7 @@ var constructor = function () {
             options.sessionTimeoutInSeconds =
                 forwarderSettings.ABKSessionTimeoutKey || 1800;
             options.sdkFlavor = 'mparticle';
-            options.enableHtmlInAppMessages =
+            options.allowUserSuppliedJavascript =
                 forwarderSettings.enableHtmlInAppMessages == 'True';
             options.doNotLoadFontAwesome =
                 forwarderSettings.doNotLoadFontAwesome == 'True';

--- a/test/tests.js
+++ b/test/tests.js
@@ -936,10 +936,9 @@ describe('Appboy Forwarder', function () {
         window.appboy.getUser().emailSet.should.equal('test2@gmail.com');
 
         // We support $Age as a reserved attribute for Braze. However, since
-        // Braze's API expects a year from us, this test will break every year,
-        // since setting the age = 10 in 2021 will mean the user is born in 2011,
-        // but setting it in 2023 means the year is 2013.
-        window.appboy.getUser().yearOfBirth.should.equal(2013);
+        // Braze's API expects a year, so we calculate expected year dynamically.
+        var expectedYearOfBirth = new Date().getFullYear() - 10;
+        window.appboy.getUser().yearOfBirth.should.equal(expectedYearOfBirth);
         window.appboy.getUser().dayOfBirth.should.equal(1);
         window.appboy.getUser().monthOfBirth.should.equal(1);
         window.appboy.getUser().phoneSet.should.equal('1234567890');


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 -  Replacing deprecated `enableHtmlInAppMessages` setting with new one `allowUserSuppliedJavascript`

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go/j/SDKE-882
