### PR TITLE
chore: Update version to 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 --
 
+## 6.0.0 - 2026-03-24
+
+⚠️ **Breaking** - The mParticle web Braze kit now supports Braze's Web SDK v6. Breaking changes can be viewed at [Braze's changelog](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/changelog/#600). There may be API changes that affect you if you call `braze` directly from your code.
+-   feat: Support Braze Web SDK V6 [#62](https://github.com/mparticle-integrations/mparticle-javascript-integration-braze/pull/62)
+    * Full details about the changes and recommended code changes can be found in the README.
+
 ## 5.0.3 - 2025-08-11
 
 -   feat: Add support to forward subscriptionGroupIds [(#57)](https://github.com/mparticle-integrations/mparticle-javascript-integration-braze/pull/57))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mparticle/web-braze-kit",
-    "version": "5.0.3",
+    "version": "6.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@mparticle/web-braze-kit",
-            "version": "5.0.3",
+            "version": "6.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@braze/web-sdk": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-braze-kit",
-    "version": "5.0.3",
+    "version": "6.0.0",
     "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
     "description": "mParticle integration sdk for Braze",
     "main": "dist/BrazeKit.common.js",

--- a/src/BrazeKit-dev.js
+++ b/src/BrazeKit-dev.js
@@ -17,7 +17,7 @@ window.braze = require('@braze/web-sdk');
 var name = 'Appboy',
     suffix = 'v6',
     moduleId = 28,
-    version = '5.0.3',
+    version = '6.0.0',
     MessageType = {
         PageView: 3,
         PageEvent: 4,


### PR DESCRIPTION
## Summary
- Bumps version to `6.0.0` in `package.json`, `package-lock.json`, `src/BrazeKit-dev.js`, and `CHANGELOG.md`

## Testing Plan
- [ ] Was this tested locally? If not, explain why.
- Version string changes only — verify all four files reflect `6.0.0`

## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
- No JIRA